### PR TITLE
docs(api/$http): fix typo in $http API Reference

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -583,7 +583,7 @@ function $HttpProvider() {
      *
      * ### Overriding the Default Transformations Per Request
      *
-     * If you wish override the request/response transformations only for a single request then provide
+     * If you wish to override the request/response transformations only for a single request then provide
      * `transformRequest` and/or `transformResponse` properties on the configuration object passed
      * into `$http`.
      *


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Docs update.

**What is the current behavior? (You can also link to an open issue here)**

A typo exists in https://docs.angularjs.org/api/ng/service/$http.

**What is the new behavior (if this is a feature change)?**

The typo is fixed.

**Does this PR introduce a breaking change?**

No.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

N/A
